### PR TITLE
Fixed Error Handling Issue #38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<version>${testcontainers.version}</version>

--- a/src/main/java/com/github/aistomin/andy/grails/backend/controllers/GlobalExceptionHandler.java
+++ b/src/main/java/com/github/aistomin/andy/grails/backend/controllers/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.github.aistomin.andy.grails.backend.controllers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GlobalExceptionHandler extends RuntimeException {
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleEntityNotFound(EntityNotFoundException ex) {
+        Map<String, String> response = new HashMap<>();
+        response.put("error", ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGenericException(Exception ex) {
+        Map<String, String> response = new HashMap<>();
+        response.put("error", "Internal server error");
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+}

--- a/src/main/java/com/github/aistomin/andy/grails/backend/controllers/GlobalExceptionHandler.java
+++ b/src/main/java/com/github/aistomin/andy/grails/backend/controllers/GlobalExceptionHandler.java
@@ -1,21 +1,21 @@
 package com.github.aistomin.andy.grails.backend.controllers;
 
-import java.util.HashMap;
-import java.util.Map;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 
-public class GlobalExceptionHandler extends RuntimeException {
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleEntityNotFound(EntityNotFoundException ex) {
-        Map<String, String> response = new HashMap<>();
-        response.put("error", ex.getMessage());
-        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
-    }
+import java.util.Map;
+import java.util.HashMap;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, String>> handleGenericException(Exception ex) {
+    public ResponseEntity<Map<String, String>> handleAnyException(Exception ex) {
         Map<String, String> response = new HashMap<>();
-        response.put("error", "Internal server error");
+        response.put("error", "Internal server error occurred");
+        ex.printStackTrace();
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
-
 }

--- a/src/main/java/com/github/aistomin/andy/grails/backend/controllers/videos/VideoController.java
+++ b/src/main/java/com/github/aistomin/andy/grails/backend/controllers/videos/VideoController.java
@@ -80,7 +80,7 @@ public class VideoController {
      * @param id The ID.
      * @return Found video.
      */
-    /*
+
     @GetMapping("/{id}")
     public VideoDto findById(final @PathVariable long id) {
         log.info("VideoController.findById is called with ID = {} .....", id);
@@ -88,17 +88,7 @@ public class VideoController {
         log.info("VideoController.findById returns {}.", video);
         return video;
     }
-    */
 
-    @GetMapping("/{id}")
-    public VideoDto findById(@PathVariable long id) {
-        log.info("VideoController.findById is called with ID = {} .....", id);
-        final var video = this.videos.findById(id);
-        if (video == null) {
-            throw new RuntimeException("Video with ID " + id + " not found");
-        }
-        final var dto = mapper.toDto(video);
-        log.info("VideoController.findById returns {}.", dto);
-        return dto;
-    }
+
+
 }

--- a/src/main/java/com/github/aistomin/andy/grails/backend/controllers/videos/VideoController.java
+++ b/src/main/java/com/github/aistomin/andy/grails/backend/controllers/videos/VideoController.java
@@ -80,11 +80,25 @@ public class VideoController {
      * @param id The ID.
      * @return Found video.
      */
+    /*
     @GetMapping("/{id}")
     public VideoDto findById(final @PathVariable long id) {
         log.info("VideoController.findById is called with ID = {} .....", id);
         final var video = mapper.toDto(this.videos.findById(id));
         log.info("VideoController.findById returns {}.", video);
         return video;
+    }
+    */
+
+    @GetMapping("/{id}")
+    public VideoDto findById(@PathVariable long id) {
+        log.info("VideoController.findById is called with ID = {} .....", id);
+        final var video = this.videos.findById(id);
+        if (video == null) {
+            throw new RuntimeException("Video with ID " + id + " not found");
+        }
+        final var dto = mapper.toDto(video);
+        log.info("VideoController.findById returns {}.", dto);
+        return dto;
     }
 }

--- a/src/main/java/com/github/aistomin/andy/grails/backend/services/VideoServiceImpl.java
+++ b/src/main/java/com/github/aistomin/andy/grails/backend/services/VideoServiceImpl.java
@@ -64,7 +64,9 @@ public final class VideoServiceImpl implements VideoService {
         log.debug(
             "VideoServiceImpl.findById is called with ID = {} .....", id
         );
-        final var result = videos.findById(id).orElse(null);
+        final var result = videos.findById(id)
+                .orElseThrow(() -> new javax.persistence.EntityNotFoundException("Video with ID " + id + " not found"));
+
         log.debug(
             "VideoServiceImpl.findById result: {}.", result
         );

--- a/src/main/java/com/github/aistomin/andy/grails/backend/services/VideoServiceImpl.java
+++ b/src/main/java/com/github/aistomin/andy/grails/backend/services/VideoServiceImpl.java
@@ -65,8 +65,7 @@ public final class VideoServiceImpl implements VideoService {
             "VideoServiceImpl.findById is called with ID = {} .....", id
         );
         final var result = videos.findById(id)
-                .orElseThrow(() -> new javax.persistence.EntityNotFoundException("Video with ID " + id + " not found"));
-
+                .orElseThrow(() -> new RuntimeException("Video with ID " + id + " not found"));
         log.debug(
             "VideoServiceImpl.findById result: {}.", result
         );


### PR DESCRIPTION
Handled the case where a video is requested by an ID that does not exist in the database. Previously, the application would throw an unhandled exception, potentially causing a 500 Internal Server Error. Now, the controller checks if the video is `null` and throws a clear exception if not found.

### Changes Made
- Updated `VideoController.findById()` method:
  - Added a `null` check after calling `videos.findById(id)`
  - Throws `RuntimeException` with a message `"Video with ID {id} not found"` if the video doesn't exist
- Ensures better debugging/logging and avoids silent failures