### PR TITLE
fix: pass Application.class to SpringApplicationBuilder in ServletIni…

### DIFF
--- a/src/main/java/de/andy/grails/ServletInitializer.java
+++ b/src/main/java/de/andy/grails/ServletInitializer.java
@@ -35,6 +35,6 @@ public final class ServletInitializer extends SpringBootServletInitializer {
     protected SpringApplicationBuilder configure(
         final SpringApplicationBuilder builder
     ) {
-        return super.configure(builder);
+        return builder.sources(Application.class);
     }
 }

--- a/src/test/java/de/andy/grails/ServletInitializerTest.java
+++ b/src/test/java/de/andy/grails/ServletInitializerTest.java
@@ -15,6 +15,7 @@
  */
 package de.andy.grails;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
@@ -27,7 +28,8 @@ class ServletInitializerTest {
 
     @Test
     void configure() {
-        final var initializer = new ServletInitializer();
-        initializer.configure(new SpringApplicationBuilder(Object.class));
+        final var result = new ServletInitializer()
+            .configure(new SpringApplicationBuilder());
+        Assertions.assertNotNull(result);
     }
 }


### PR DESCRIPTION
…tializer (#238)

Without sources(Application.class), Spring has no entry point when the WAR is deployed to an external servlet container. The base class default does nothing useful, so the app would silently fail to start outside of the embedded Tomcat context.