### PR TITLE
fix: use JRE instead of JDK in Docker runtime image (#239)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN ./mvnw clean package -DskipTests
 
 # ---- Runtime Image ----
-FROM eclipse-temurin:21-jdk
+FROM eclipse-temurin:21-jre
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
The runtime stage only needs to execute the application, not compile it. Shipping the full JDK increases image size and unnecessarily expands the attack surface in production. The builder stage retains eclipse-temurin:21-jdk as it requires the compiler.