### PR TITLE
fix: update stale Javadoc on VideoServiceImpl (#240)

### DIFF
--- a/src/main/java/de/andy/grails/services/VideoServiceImpl.java
+++ b/src/main/java/de/andy/grails/services/VideoServiceImpl.java
@@ -23,8 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Temporary implementation of the {@link VideoService}. For now, we just work
- * with some hardcoded values that we store in the static variable.
+ * Implementation of {@link VideoService} backed by {@link VideoRepository}.
  *
  * @since 0.1
  */


### PR DESCRIPTION
                                                                     The class-level comment described a long-gone temporary implementation with hardcoded static values. The class now delegates to VideoRepository, so the Javadoc is updated to reflect that.