### PR TITLE
fix: correct stale Javadoc on DataGenerator (#241)

### DIFF
--- a/src/main/java/de/andy/grails/model/DataGenerator.java
+++ b/src/main/java/de/andy/grails/model/DataGenerator.java
@@ -26,7 +26,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 /**
- * Video repository.
+ * Generates initial seed data (videos and web links) on first application
+ * startup if none already exist in the database.
  *
  * @since 0.3
  */


### PR DESCRIPTION
The class-level comment incorrectly described it as a "Video repository". DataGenerator is a seed-data component that populates both videos and web links on first application startup if none exist in the database.