### PR TITLE
fix(#252): hide actuator health details to prevent info leakage in pr…

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ management:
         include: health,info
   endpoint:
     health:
-      show-details: always
+      show-details: never
 info:
   app:
     name: andy.grails.backend


### PR DESCRIPTION
…oduction

Changed `show-details: always` to `show-details: never` in application.yml so that /actuator/health returns only the overall status without exposing DB connection info, memory, or disk space.