### PR TITLE
fix(#253): reject non-positive video IDs with 400 Bad Request

### DIFF
--- a/src/main/java/de/andy/grails/controllers/videos/VideoController.java
+++ b/src/main/java/de/andy/grails/controllers/videos/VideoController.java
@@ -18,7 +18,9 @@ package de.andy.grails.controllers.videos;
 import de.andy.grails.exceptions.NotFoundException;
 import de.andy.grails.services.VideoService;
 import de.andy.grails.services.mappers.VideoMapper;
+import jakarta.validation.constraints.Min;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +34,7 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/videos")
+@Validated
 @Slf4j
 public class VideoController {
 
@@ -82,7 +85,7 @@ public class VideoController {
      * @return Found video.
      */
     @GetMapping("/{id}")
-    public VideoDto findById(final @PathVariable long id) {
+    public VideoDto findById(final @Min(1) @PathVariable long id) {
         log.info("VideoController.findById is called with ID = {} .....", id);
         final var found = this.videos.findById(id);
         final var video = mapper.toDto(found.orElseThrow(() -> {

--- a/src/main/java/de/andy/grails/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/de/andy/grails/exceptions/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@
  */
 package de.andy.grails.exceptions;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -53,6 +54,21 @@ public final class GlobalExceptionHandler {
             HttpStatus.INTERNAL_SERVER_ERROR,
             "Internal server error occurred."
         );
+    }
+
+    /**
+     * Handle constraint violation exceptions (e.g. invalid path variables).
+     *
+     * @param ex The constraint violation exception.
+     * @return Error response.
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorResponse handleConstraintViolationException(
+        final ConstraintViolationException ex
+    ) {
+        return new ErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
     /**

--- a/src/test/java/de/andy/grails/controllers/videos/VideoControllerTest.java
+++ b/src/test/java/de/andy/grails/controllers/videos/VideoControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException.BadRequest;
 import org.springframework.web.client.HttpClientErrorException.NotFound;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +74,42 @@ class VideoControllerTest extends IntegrationTest {
         );
         Assertions.assertTrue(
             video.description().endsWith("vel turpis egestas ullamcorper.\n")
+        );
+    }
+
+    /**
+     * Test that we return 400 when the video ID is negative.
+     */
+    @Test
+    void testFindByIdNegative() {
+        final var exception = Assertions.assertThrows(
+            BadRequest.class,
+            () -> restClient().get()
+                .uri("/videos/-1")
+                .retrieve()
+                .body(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+        );
+        Assertions.assertEquals(
+            HttpStatus.BAD_REQUEST, exception.getStatusCode()
+        );
+    }
+
+    /**
+     * Test that we return 400 when the video ID is zero.
+     */
+    @Test
+    void testFindByIdZero() {
+        final var exception = Assertions.assertThrows(
+            BadRequest.class,
+            () -> restClient().get()
+                .uri("/videos/0")
+                .retrieve()
+                .body(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+        );
+        Assertions.assertEquals(
+            HttpStatus.BAD_REQUEST, exception.getStatusCode()
         );
     }
 


### PR DESCRIPTION
Added @Validated on VideoController and @Min(1) on the id path variable so that GET /videos/-1 and GET /videos/0 return 400 instead of 500. Added ConstraintViolationException handler in GlobalExceptionHandler and two new integration tests covering the negative and zero ID cases.