### PR TITLE
ci(#277): upload coverage reports on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,16 @@ jobs:
       - name: Build with Maven
         run: mvn clean install package
       - name: Upload coverage reports to Codecov
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        # Upload on failure too: jacoco:check enforces 100% coverage, so a PR
+        # that adds uncovered lines fails the build — and that is exactly the
+        # PR whose diff coverage we want to see.
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: aistomin/andy.grails.backend
+          files: ./target/site/jacoco/jacoco.xml
+          disable_search: true
       - name: Extract short SHA
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes #277

## Problem

The Codecov step was guarded to master pushes only:

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/master'
```

so it was reported as `skipped` on every PR run. No report ever reached Codecov for a PR head commit, and diff coverage could not be computed for the change under review.

## Fix

- Replace the guard with `if: ${{ !cancelled() }}` so the step runs on `pull_request` as well as `push`. It deliberately runs on a **failed** build too: `jacoco:check` enforces 100% line coverage, so a PR that adds uncovered lines fails the build — and that is precisely the PR whose diff coverage is worth seeing. `default-report` is declared before `default-check` and both bind to `verify`, so the XML is already on disk when the check fails.
- Point the uploader at `./target/site/jacoco/jacoco.xml` explicitly with `disable_search: true` instead of relying on auto-search.

Uploads on `master` are unaffected — `!cancelled()` is true on a green push. The guards on `publish_to_docker_hub` and `update_parent_repo` are untouched, so those jobs still run only on master pushes.

## Verification

This PR verifies itself: its own CI run should show `Upload coverage reports to Codecov` with conclusion `success` rather than `skipped`, and a Codecov status check reporting diff coverage.

## Notes

- `CODECOV_TOKEN` already exists as an Actions secret (added 2025-03-23); no new configuration is needed.
- `fail_ci_if_error` is left at its default `false`, so a Codecov outage cannot break CI.
- Dependabot-triggered runs read the *Dependabot* secret store, which is empty on this repo, so those PRs fall back to a tokenless upload. That is accepted for now and is non-fatal; it can be resolved later with `gh secret set CODECOV_TOKEN --app dependabot` — settings only, no code change.