### PR TITLE
build(#276): add github-actions ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
     commit-message:
       prefix: "build" # Conventional Commits type, e.g. build(deps): bump ...
       include: "scope" # Adds (deps) / (deps-dev) scope
+  - package-ecosystem: "github-actions"
+    directory: "/" # Dependabot always scans .github/workflows from the root
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build" # Conventional Commits type, e.g. build(deps): bump ...
+      include: "scope" # Adds (deps) / (deps-dev) scope


### PR DESCRIPTION
Fixes #276

## Problem

`.github/dependabot.yml` covered only the `maven` manifest at `/`, so the GitHub Actions used by `ci.yml` were never updated. All six had drifted behind:

| Action | Pinned | Latest |
|---|---|---|
| `actions/checkout` | v4 | v7.0.1 |
| `actions/setup-java` | v4 | v6.0.0 |
| `codecov/codecov-action` | v5 | v7.0.0 |
| `docker/login-action` | v3 | v4.6.0 |
| `docker/setup-buildx-action` | v3 | v4.3.0 |
| `docker/build-push-action` | v5 | v7.3.0 |

Two of these build and push the backend image to Docker Hub, so stale versions eventually break publishing, not just the build.

## Fix

Add a `github-actions` entry alongside the existing `maven` one, with an identical `commit-message` block so action bumps land as `build(deps): bump ...`, consistent with Conventional Commits.

Deliberately **not** included:

- **No grouping.** Unlike the frontend's `angular` group — which exists because Angular packages carry exact-version peer deps — GitHub Actions are mutually independent. Six separate PRs each pass or fail on their own merits; one grouped PR going red would just mean bisecting by hand.
- **No `open-pull-requests-limit`.** The default of 5 means one of the six bumps is throttled until another merges. That is a one-week, self-correcting artifact of the initial catch-up, not worth a permanent setting.

## Acceptance criteria

- [x] `github-actions` entry present in `.github/dependabot.yml`
- [x] The entry carries the same `commit-message` block as the `maven` entry
- [ ] Dependabot opens PRs for the outdated actions — verified after merge

## Verification

Dependabot reads `dependabot.yml` from the default branch only, so nothing is observable until this merges. Afterwards: Insights → Dependency graph → Dependabot → **Check for updates** on the `github-actions` row forces an immediate run. That tab is also where an invalid config would surface, since a schema error fails no CI check.

Expect five PRs initially, with the sixth held back by the default limit.

## Notes

- Same gap as aistomin/andy.grails#82 (parent repo) and aistomin/maven-browser#508.
- The frontend repo has the same missing entry with no issue filed yet.
- Each bump should be checked against the whole of `ci.yml`, including the Docker build/push job and the Codecov upload step.