### PR TITLE
docs(#286): add Apache 2.0 LICENSE and fill pom metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2025 Andrej Istomin
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/aistomin/andy.grails.backend/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/aistomin/andy.grails.backend/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/aistomin/andy.grails.backend/graph/badge.svg?token=WZFAART6QM)](https://codecov.io/gh/aistomin/andy.grails.backend)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 This is the backend service for the [Andy Grails' website](https://andy-grails.de/).  
 It is a Java Spring Boot application providing RESTful APIs to serve music data, media, and metadata consumed by the frontend.
@@ -64,3 +65,10 @@ request, please run the full Maven build:
 
 **Note:** We use Testcontainers — make sure Docker is running when you build.
 Also, check the [system requirements](#system-requirements).
+
+## License
+
+This project is licensed under the [Apache License, Version 2.0](LICENSE).
+
+Every source file carries the same grant in its header, alongside
+`Copyright (c) 2025 Andrej Istomin`.

--- a/pom.xml
+++ b/pom.xml
@@ -24,18 +24,25 @@
 	<packaging>war</packaging>
 	<name>andy.grails.backend</name>
 	<description>Andy Grails' Website. Backend</description>
-	<url/>
+	<url>https://github.com/aistomin/andy.grails.backend</url>
 	<licenses>
-		<license/>
+		<license>
+			<name>The Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
 	</licenses>
 	<developers>
-		<developer/>
+		<developer>
+			<name>Andrej Istomin</name>
+			<email>contact@aistomin.com</email>
+			<organization>Andrej Istomin</organization>
+			<organizationUrl>https://aistomin.com/</organizationUrl>
+		</developer>
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection>scm:git:github.com:aistomin/andy.grails.backend.git</connection>
+		<developerConnection>scm:git:github.com:aistomin/andy.grails.backend.git</developerConnection>
+		<url>https://github.com/aistomin/andy.grails.backend</url>
 	</scm>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Closes #286.

The repository granted no licence despite all 50 source files carrying an
Apache 2.0 header enforced by the Checkstyle `Header` module.

- Add a root `LICENSE` — the same Apache 2.0 notice as `conf/LICENSE`, with
  the `/* */` comment markers stripped and the matching copyright line
  `Copyright (c) 2025 Andrej Istomin`. Verified programmatically to be
  identical to the enforced header.
- Fill the empty `<url>`, `<licenses>`, `<developers>` and `<scm>` stubs in
  `pom.xml`, mirroring the structure used in
  [aistomin/maven-browser](https://github.com/aistomin/maven-browser). The
  empty `<tag/>` is removed rather than left blank.
- Add a licence badge and a `## License` section to `README.md`.

`conf/LICENSE` and `conf/checkstyle.xml` are deliberately untouched: that file
is the Java header template the `Header` module compares against, which needs
comment syntax the root `LICENSE` cannot provide.

### Note on the third checkbox

The issue asks to verify that GitHub's detector shows an `Apache-2.0` badge in
the sidebar. It will not, and that is a deliberate choice. GitHub's `licensee`
only matches near-verbatim full licence texts, so the short notice used here —
chosen for consistency with `maven-browser` and with this repo's own file
headers — is reported as `NOASSERTION`. (`maven-browser` currently reports
`NOASSERTION` for exactly this reason.) The README badge covers the visible
signal instead. Suggest amending that checkbox before closing.

### Verification

`./mvnw clean install package javadoc:javadoc` on JDK 21: BUILD SUCCESS,
0 Checkstyle violations, 16 tests / 0 failures / 0 errors / 0 skipped.